### PR TITLE
Use template literals

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,2 +1,2 @@
-export { Client, ClientConfig } from "./src/client.ts";
+export { Client, ClientConfig, SQL } from "./src/client.ts";
 export { Connection } from "./src/connection.ts";


### PR DESCRIPTION
I haven't tested it. Please test it if it works correctly.

Usage:
```ts
import { Client, SQL } from "https://deno.land/x/mysql/mod.ts";
const client = await new Client().connect({...options...});

client.query(SQL`select $${"name"} from $${"users"} where id = ${5}`);
// is exactly the same as:
client.query("select  ??  from  ??  where id =  ?", [ "name", "users", 5 ]);
```