### PR TITLE
Updated byteFormat dependency to avoid dependency 404 issues

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,7 +1,7 @@
 export type { Deferred } from "https://deno.land/std@0.74.0/async/mod.ts";
 export { deferred, delay } from "https://deno.land/std@0.74.0/async/mod.ts";
 export { decode, encode } from "https://deno.land/std@0.74.0/encoding/utf8.ts";
-export { format as byteFormat } from "https://deno.land/x/bytes_formater@v1.3.0/mod.ts";
+export { format as byteFormat } from "https://deno.land/x/bytes_formater@v1.4.0/mod.ts";
 export { Hash } from "https://deno.land/x/checksum@1.4.0/mod.ts";
 export { sha256 } from "https://deno.land/x/sha256@v1.0.2/mod.ts";
 export { replaceParams } from "https://deno.land/x/sql_builder@v1.7.0/util.ts";


### PR DESCRIPTION
Original error:

```
(base) ➜  app deno run --allow-net --allow-read --allow-env mod.ts
Download https://github.com/alejandroq/mysql/raw/master/mod.ts
Download https://raw.githubusercontent.com/alejandroq/mysql/master/src/constant/capabilities.ts
Download https://raw.githubusercontent.com/alejandroq/mysql/master/src/constant/mysql_types.ts
Download https://raw.githubusercontent.com/alejandroq/mysql/master/src/auth.ts
Download https://raw.githubusercontent.com/alejandroq/mysql/master/src/constant/charset.ts
Download https://deno.land/std@v0.63.0/fmt/colors.ts
Warning std versions prefixed with 'v' were deprecated recently. Please change your import to https://deno.land/std@0.63.0/fmt/colors.ts (at https://deno.land/std@v0.63.0/fmt/colors.ts)
error: Import 'https://deno.land/std@v0.63.0/fmt/colors.ts' failed: 404 Not Found
    at https://deno.land/x/bytes_formater@v1.3.0/deps.ts:1:0
```

After the patch it downloaded all deps with no issues.

