### PR TITLE
Fix empty execute result array for MariaDB version 10.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           - mysql:8
           - mysql:latest
           - mariadb:5.5
+          - mariadb:10.1
           - mariadb:10.2
           - mariadb:10.3
           - mariadb:10.4

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -162,7 +162,7 @@ export class Connection {
    * and "x.y.z-MariaDB-[build-infos]" for 5.x versions
    *   eg "5.5.64-MariaDB-1~trusty"
    */
-  private lessThan57(): Boolean {
+  private lessThan5_7(): Boolean {
     const version = this.serverVersion;
     if (!version.includes("MariaDB")) return version < "5.7.0";
     const segments = version.split("-");
@@ -232,7 +232,7 @@ export class Connection {
       }
 
       const rows = [];
-      if (this.lessThan57()) {
+      if (this.lessThan5_7()) {
         // EOF(less than 5.7)
         receive = await this.nextPacket();
         if (receive.type !== "EOF") {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -172,6 +172,13 @@ export class Connection {
     return false;
   }
 
+  /** Checks if the MariaDB version is 10.1 */
+  private isMariaDBAndVersion10_1(): Boolean {
+    const version = this.serverVersion;
+    if (!version.includes("MariaDB")) return false;
+    return version.includes("5.5.5-10.1");
+  }
+
   /** Close database connection */
   close(): void {
     if (this.state != ConnectionState.CLOSED) {
@@ -232,8 +239,8 @@ export class Connection {
       }
 
       const rows = [];
-      if (this.lessThan5_7()) {
-        // EOF(less than 5.7)
+      if (this.lessThan5_7() || this.isMariaDBAndVersion10_1()) {
+        // EOF(less than 5.7 or mariadb version 10.1)
         receive = await this.nextPacket();
         if (receive.type !== "EOF") {
           throw new ProtocolError();


### PR DESCRIPTION
I don't know why, but MariaDB version 10.1 behaves like < 5.7.