### PR TITLE
Changes to support big data actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # deno_mysql
 
->**NOTE!!** This is a fork of the original [denodrivers/mysql](https://github.com/denodrivers/mysql) package. This one is optimized for some memory improvements. Changes done here will BREAK YOUR IMPLEMENTATION if you used the original `denodrivers/mysql` package.
-
 [![Build Status](https://github.com/manyuanrong/deno_mysql/workflows/ci/badge.svg?branch=master)](https://github.com/manyuanrong/deno_mysql/actions)
 ![GitHub](https://img.shields.io/github/license/manyuanrong/deno_mysql.svg)
 ![GitHub release](https://img.shields.io/github/release/manyuanrong/deno_mysql.svg)

--- a/README.md
+++ b/README.md
@@ -107,21 +107,31 @@ console.log(users, queryWithParams);
 There are two ways to execute an SQL statement.
 
 First and default one will return you an `rows` key containing an array of rows:
+
 ```ts
 const { rows: users } = await client.execute(`select * from users`);
 console.log(users);
 ```
 
-The second one will return you an `iterator` key containing an `[Symbol.asyncIterator]` property:
+The second one will return you an `iterator` key containing an
+`[Symbol.asyncIterator]` property:
+
 ```ts
-// note the third parameter of execute() method.
-const { iterator: users } = await client.execute(`select * from users`, /* params: */ [], /* iterator: */ false);
-for await (const user of users) {
-    console.log(user)
-}
+await client.useConnection(async (conn) => {
+  // note the third parameter of execute() method.
+  const { iterator: users } = await conn.execute(
+    `select * from users`,
+    /* params: */ [],
+    /* iterator: */ false,
+  );
+  for await (const user of users) {
+    console.log(user);
+  }
+});
 ```
 
-The second method is recommended only for SELECT queries that might contain many results (e.g. 100k rows).
+The second method is recommended only for SELECT queries that might contain many
+results (e.g. 100k rows).
 
 ### transaction
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # deno_mysql
 
+>**NOTE!!** This is a fork of the original [denodrivers/mysql](https://github.com/denodrivers/mysql) package. This one is optimized for some memory improvements. Changes done here will BREAK YOUR IMPLEMENTATION if you used the original `denodrivers/mysql` package.
+
 [![Build Status](https://github.com/manyuanrong/deno_mysql/workflows/ci/badge.svg?branch=master)](https://github.com/manyuanrong/deno_mysql/actions)
 ![GitHub](https://img.shields.io/github/license/manyuanrong/deno_mysql.svg)
 ![GitHub release](https://img.shields.io/github/release/manyuanrong/deno_mysql.svg)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,27 @@ const queryWithParams = await client.query(
 console.log(users, queryWithParams);
 ```
 
+### execute
+
+There are two ways to execute an SQL statement.
+
+First and default one will return you an `rows` key containing an array of rows:
+```ts
+const { rows: users } = await client.execute(`select * from users`);
+console.log(users);
+```
+
+The second one will return you an `iterator` key containing an `[Symbol.asyncIterator]` property:
+```ts
+// note the third parameter of execute() method.
+const { iterator: users } = await client.execute(`select * from users`, /* params: */ [], /* iterator: */ false);
+for await (const user of users) {
+    console.log(user)
+}
+```
+
+The second method is recommended only for SELECT queries that might contain many results (e.g. 100k rows).
+
 ### transaction
 
 ```ts

--- a/src/client.ts
+++ b/src/client.ts
@@ -88,13 +88,24 @@ export class Client {
   }
 
   /**
-   * excute sql
+   * execute sql
    * @param sql sql string
    * @param params query params
    */
   async execute(sql: string, params?: any[]): Promise<ExecuteResult> {
     return await this.useConnection(async (connection) => {
       return await connection.execute(sql, params);
+    });
+  }
+
+  /**
+   * execute sql
+   * @param sql sql string
+   * @param params query params
+   */
+  async* execute_generator(sql: string, params?: any[]): AsyncGenerator<any, any, any> {
+    return await this.useConnection(async (connection) => {
+      return connection.exec_generator(sql, params)
     });
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -91,11 +91,10 @@ export class Client {
    * execute sql
    * @param sql sql string
    * @param params query params
-   * @param iterator whether to return an iterator or not
    */
-  async execute(sql: string, params?: any[], iterator = false): Promise<ExecuteResult> {
+  async execute(sql: string, params?: any[]): Promise<ExecuteResult> {
     return await this.useConnection(async (connection) => {
-      return await connection.execute(sql, params, iterator);
+      return await connection.execute(sql, params);
     });
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -77,7 +77,7 @@ export class Client {
   }
 
   /**
-   * excute query sql
+   * execute query sql
    * @param sql query sql string
    * @param params query params
    */
@@ -91,37 +91,12 @@ export class Client {
    * execute sql
    * @param sql sql string
    * @param params query params
+   * @param iterator whether to return an iterator or not
    */
-  async execute(sql: string, params?: any[]): Promise<ExecuteResult> {
+  async execute(sql: string, params?: any[], iterator = false): Promise<ExecuteResult> {
     return await this.useConnection(async (connection) => {
-      return await connection.execute(sql, params);
+      return await connection.execute(sql, params, iterator);
     });
-  }
-
-  /**
-   * execute sql
-   * @param sql sql string
-   * @param params query params
-   */
-  async* execute_generator(sql: string, params?: any[]): AsyncGenerator<any, any, any> {
-    if (!this._pool) {
-      throw new Error("Unconnected");
-    }
-
-    const connection = await this._pool!.pop();
-
-    try {
-      const generator = connection.execute_generator(sql, params)
-      for await (let row of generator) {
-        yield row
-      }
-    } finally {
-      if (connection.state == ConnectionState.CLOSED) {
-        connection.removeFromPool();
-      } else {
-        connection.returnToPool();
-      }
-    }
   }
 
   async useConnection<T>(fn: (conn: Connection) => Promise<T>) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,4 +1,3 @@
-import { byteFormat, delay } from "../deps.ts";
 import { ClientConfig } from "./client.ts";
 import {
   ConnnectionError,
@@ -31,13 +30,14 @@ export enum ConnectionState {
 }
 
 /**
- * Result for excute sql
+ * Result for execute sql
  */
 export type ExecuteResult = {
   affectedRows?: number;
   lastInsertId?: number;
   fields?: FieldInfo[];
   rows?: any[];
+  iterator?: any;
 };
 
 /** Connection for mysql */
@@ -248,8 +248,13 @@ export class Connection {
    * execute sql
    * @param sql sql string
    * @param params query params
+   * @param iterator whether to return an ExecuteIteratorResult or ExecuteResult
    */
-  async execute(sql: string, params?: any[]): Promise<ExecuteResult> {
+  async execute(
+    sql: string,
+    params?: any[],
+    iterator = false,
+  ): Promise<ExecuteResult> {
     if (this.state != ConnectionState.CONNECTED) {
       if (this.state == ConnectionState.CLOSED) {
         throw new ConnnectionError("Connection is closed");
@@ -289,79 +294,51 @@ export class Connection {
         }
       }
 
-      while (true) {
-        receive = await this.nextPacket();
-        if (receive.type === PacketType.EOF_Packet) {
-          break;
-        } else {
-          const row = parseRow(receive.body, fields);
-          rows.push(row);
+      if (!iterator) {
+        while (true) {
+          receive = await this.nextPacket();
+          if (receive.type === PacketType.EOF_Packet) {
+            break;
+          } else {
+            const row = parseRow(receive.body, fields);
+            rows.push(row);
+          }
         }
+        return { rows, fields };
       }
-      return { rows, fields };
+
+      return {
+        fields,
+        iterator: this.buildIterator(fields),
+      };
     } catch (error) {
       this.close();
       throw error;
     }
   }
 
-  /**
-   * execute sql
-   * @param sql sql string
-   * @param params query params
-   */
-  async* execute_generator(sql: string, params?: any[]): AsyncGenerator<any, any, any> {
-    if (this.state != ConnectionState.CONNECTED) {
-      if (this.state == ConnectionState.CLOSED) {
-        throw new ConnnectionError("Connection is closed");
-      } else {
-        throw new ConnnectionError("Must be connected first");
+  private buildIterator(fields: FieldInfo[]): any {
+    const next = async () => {
+      const receive = await this.nextPacket();
+
+      if (receive.type === PacketType.EOF_Packet) {
+        return { done: true };
       }
+
+      const value = parseRow(receive.body, fields);
+
+      return {
+        done: false,
+        value,
+      };
     }
-    const data = buildQuery(sql, params);
-    try {
-      await new SendPacket(data, 0).send(this.conn!);
-      let receive = await this.nextPacket();
-      if (receive.type === PacketType.OK_Packet) {
-        receive.body.skip(1);
-        // TODO -- unsupported for this operation
-        // return {
-        //   affectedRows: receive.body.readEncodedLen(),
-        //   lastInsertId: receive.body.readEncodedLen(),
-        // };
-      } else if (receive.type !== PacketType.Result) {
-        throw new ProtocolError();
-      }
-      let fieldCount = receive.body.readEncodedLen();
-      const fields: FieldInfo[] = [];
-      while (fieldCount--) {
-        const packet = await this.nextPacket();
-        if (packet) {
-          const field = parseField(packet.body);
-          fields.push(field);
-        }
-      }
 
-      // const rows = [];
-      if (this.lessThan5_7() || this.isMariaDBAndVersion10_0Or10_1()) {
-        // EOF(less than 5.7 or mariadb version is 10.0 or 10.1)
-        receive = await this.nextPacket();
-        if (receive.type !== PacketType.EOF_Packet) {
-          throw new ProtocolError();
-        }
-      }
-
-      while (true) {
-        receive = await this.nextPacket();
-        if (receive.type === PacketType.EOF_Packet) {
-          break;
-        } else {
-          yield parseRow(receive.body, fields);
-        }
-      }
-    } catch (error) {
-      this.close();
-      throw error;
+    return {
+      [Symbol.asyncIterator]: () => {
+        return {
+          next,
+        };
+      },
     }
   }
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -331,7 +331,7 @@ export class Connection {
         done: false,
         value,
       };
-    }
+    };
 
     return {
       [Symbol.asyncIterator]: () => {
@@ -339,6 +339,6 @@ export class Connection {
           next,
         };
       },
-    }
+    };
   }
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -310,7 +310,7 @@ export class Connection {
    * @param sql sql string
    * @param params query params
    */
-  async* exec_generator(sql: string, params?: any[]): AsyncGenerator<any, any, any> {
+  async* execute_generator(sql: string, params?: any[]): AsyncGenerator<any, any, any> {
     if (this.state != ConnectionState.CONNECTED) {
       if (this.state == ConnectionState.CLOSED) {
         throw new ConnnectionError("Connection is closed");
@@ -324,6 +324,7 @@ export class Connection {
       let receive = await this.nextPacket();
       if (receive.type === PacketType.OK_Packet) {
         receive.body.skip(1);
+        // TODO -- unsupported for this operation
         // return {
         //   affectedRows: receive.body.readEncodedLen(),
         //   lastInsertId: receive.body.readEncodedLen(),
@@ -355,11 +356,9 @@ export class Connection {
         if (receive.type === PacketType.EOF_Packet) {
           break;
         } else {
-          const row = parseRow(receive.body, fields);
-          yield row
+          yield parseRow(receive.body, fields);
         }
       }
-      // return { rows, fields };
     } catch (error) {
       this.close();
       throw error;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -310,7 +310,7 @@ export class Connection {
    * @param sql sql string
    * @param params query params
    */
-  async *exec_generator(sql: string, params?: any[]): AsyncGenerator<ExecuteResult> {
+  async* exec_generator(sql: string, params?: any[]): AsyncGenerator<any, any, any> {
     if (this.state != ConnectionState.CONNECTED) {
       if (this.state == ConnectionState.CLOSED) {
         throw new ConnnectionError("Connection is closed");

--- a/test.ts
+++ b/test.ts
@@ -287,6 +287,25 @@ testWithClient(async function testLargeQueryAndResponse(client) {
   );
 });
 
+testWithClient(async function testExecuteIterator(client) {
+  await client.useConnection(async (conn) => {
+    await conn.execute(`DROP TABLE IF EXISTS numbers`);
+    await conn.execute(`CREATE TABLE numbers (num INT NOT NULL)`);
+    await conn.execute(
+      `INSERT INTO numbers (num) VALUES ${
+        new Array(64).fill(0).map((v, idx) => `(${idx})`).join(",")
+      }`,
+    );
+    const r = await conn.execute(`SELECT num FROM numbers`, [], true);
+    let count = 0;
+    for await (const row of r.iterator) {
+      assertEquals(row.num, count);
+      count++;
+    }
+    assertEquals(count, 64);
+  });
+});
+
 registerTests();
 
 Deno.test("configLogger()", async () => {


### PR DESCRIPTION
This PR closes #111.

The main issue I've encountered with this lib was that it collected MySQL row packets in an array, filling up the memory. In my specific case, I needed a way to prevent this kind of memory fill-up, especially when using Worker to delegate various tasks.

The initial implementation, as seen in older commits, considered the usage of a separate generator method called `execute_generator`. It had some drawbacks, too:
- I couldn't use it well using pooled connection, so I had to detach a connection (which eventually led to other issues, but it did the job)
- I had to duplicate much code to "make it work"

After @lideming's suggestion in #111, I've started to play around with `execute` instead, and return an `iterator` property which:
- reduced the need of `execute_generator` method
- won't break existing projects
- usage of iterator is opt-in, so you can use both `rows` and `iterator` methods

So the API now looks like this:

```ts
async execute(sql: string, params?: any[], iterator = false): Promise<ExecuteResult>
```

The usage is pretty simple and straight-forward:
```ts
const { iterator: users } = connection.execute("select * from foo", undefined, true)
for await (const user of users) {
    // handle row
}
```

Additionally, I've corrected some typos that I noticed (e.g. `excute` -> `execute`, `ConnnectionError` -> `ConnectionError`).

As for the testing, I've added a test, but I couldn't run them. Deno complained that some lib uses `const foo = require('./bla')`, so IDK now to fix / update them. However, I've tested it in my project and fetching 10k rows went brrrrrrrrr, with only ~3GB RAM usage (context: each row is processed in a worker, which fills up every single thread. a single worker does additional 5 SELECT + INSERT).

If there's something more to do, it can be done.
