### PR TITLE
Added function: Connection.resetSessionState().

### DIFF
--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -47,13 +47,13 @@ export class BufferReader {
   readNullTerminatedString(): string {
     let end = this.buffer.indexOf(0x00, this.pos);
     if (end === -1) end = this.buffer.length;
-    const buf = this.buffer.slice(this.pos, end);
+    const buf = this.buffer.subarray(this.pos, end);
     this.pos += buf.length + 1;
     return decode(buf);
   }
 
   readString(len: number): string {
-    const str = decode(this.buffer.slice(this.pos, this.pos + len));
+    const str = decode(this.buffer.subarray(this.pos, this.pos + len));
     this.pos += len;
     return str;
   }
@@ -105,7 +105,7 @@ export class BufferWriter {
 
   writeBuffer(buffer: Uint8Array): BufferWriter {
     if (buffer.length > this.capacity) {
-      buffer = buffer.slice(0, this.capacity);
+      buffer = buffer.subarray(0, this.capacity);
     }
     this.buffer.set(buffer, this.pos);
     this.pos += buffer.length;

--- a/src/client.ts
+++ b/src/client.ts
@@ -109,7 +109,7 @@ export class Client {
       if (connection.state == ConnectionState.CLOSED) {
         connection.removeFromPool();
       } else {
-        connection.returnToPool();
+        await connection.returnToPool();
       }
     }
   }

--- a/src/packets/builders/auth_switch_response.ts
+++ b/src/packets/builders/auth_switch_response.ts
@@ -1,0 +1,18 @@
+import auth from "../../auth.ts";
+import { BufferWriter } from "../../buffer.ts";
+
+/** @ignore */
+export function buildAuthSwitchResponse(
+  authPluginName: string,
+  seed: Uint8Array,
+  password: string
+): Uint8Array {
+  const authData = auth(
+    authPluginName,
+    password,
+    seed
+  );
+  const writer = new BufferWriter(new Uint8Array(authData.length));
+  writer.writeBuffer(authData);
+  return writer.wroteData;
+}

--- a/src/packets/builders/change_user.ts
+++ b/src/packets/builders/change_user.ts
@@ -1,0 +1,11 @@
+import { BufferWriter } from "../../buffer.ts";
+
+/** @ignore */
+export function buildChangeUser(authPluginName: string, username: string, db: string): Uint8Array {
+  const writer = new BufferWriter(new Uint8Array(128));
+  writer.write(0x11); // COM_CHANGE_USER
+  writer.writeNullTerminatedString(username);
+  writer.write(authPluginName.length).writeString(authPluginName);
+  writer.writeNullTerminatedString(db);
+  return writer.buffer;
+}


### PR DESCRIPTION
While recycling connections in pool, it's possible to leave a connection in bad state, when it locks tables, or holds user-space locks acquired by "SELECT Get_lock('Lock name', 0')".

This connection can return to pool and be idle for long time, and whole database server will suffer from connections being stuck.

It's good practice to reset connection state before returning it to the pool by sending COM_CHANGE_USER request.

I implemented this feature.