### PR TITLE
fix: update god_crypto

### DIFF
--- a/src/auth_plugin/crypt.ts
+++ b/src/auth_plugin/crypt.ts
@@ -1,4 +1,4 @@
-import { RSA } from "https://deno.land/x/god_crypto@v0.2.0/mod.ts";
+import { RSA } from "https://deno.land/x/god_crypto@v1.4.10/mod.ts";
 function encryptWithPublicKey(key: string, data: Uint8Array): Uint8Array {
   const publicKey = RSA.parseKey(key);
   return RSA.encrypt(data, publicKey);


### PR DESCRIPTION
alternative to #132 

This PR updates `god_crypto` from 0.2.0 to 1.4.10 to prevent the import error. Closes #131 