### PR TITLE
Fix typo in client's connect method docstring

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -56,7 +56,7 @@ export class Client {
   /**
    * connect to database
    * @param config config for client
-   * @returns Clinet instance
+   * @returns Client instance
    */
   async connect(config: ClientConfig): Promise<Client> {
     this.config = {


### PR DESCRIPTION
Found a small typo in the client connect method's docstring.